### PR TITLE
Make log sends async in base.py

### DIFF
--- a/bot/cogs/contest/base.py
+++ b/bot/cogs/contest/base.py
@@ -26,7 +26,7 @@ class ContestManager(commands.Cog):
         logs_channel = await get_logs_channel(self.bot, guild_id=guild_id)
         submission_channel = await get_submission_channel(self.bot, message.guild.id)
 
-        def log_to_logs_channel(title, description, color=discord.Color.default(), image=None):
+        async def log_to_logs_channel(title, description, color=discord.Color.default(), image=None):
             if logs_channel:
                 embed = create_logs_embed(
                     title=title,
@@ -35,11 +35,12 @@ class ContestManager(commands.Cog):
                     image=image,
                     thumbnails=message.author.avatar.url if message.author.avatar else None
                 )
-                return logs_channel.send(embed=embed)
+                msg = await logs_channel.send(embed=embed)
+                return msg
             return None
 
         if not submission_channel:
-            log_to_logs_channel(
+            await log_to_logs_channel(
                 title="Submission Channel Not Configured",
                 description=f"{message.author.mention} attempted to submit but the submission channel is not set.\nUse `/contest_submission_channel` to set it.",
                 color=discord.Color.red()
@@ -47,7 +48,7 @@ class ContestManager(commands.Cog):
             return
 
         if message.channel.id != submission_channel.id:
-            log_to_logs_channel(
+            await log_to_logs_channel(
                 title="Invalid Submission Location",
                 description=f"{message.author.mention} tried to submit in <#{message.channel.id}> instead of <#{submission_channel.id}>.",
                 color=discord.Color.orange()
@@ -55,7 +56,7 @@ class ContestManager(commands.Cog):
             return
 
         if not attachment:
-            log_to_logs_channel(
+            await log_to_logs_channel(
                 title="No Attachment Found",
                 description=f"{message.author.mention} submitted a message without an image attachment.",
                 color=discord.Color.orange()
@@ -75,14 +76,14 @@ class ContestManager(commands.Cog):
             await resize_and_save_image(image_bytes, output_path)
             print(f"Saved image for {user_id} at {output_path}")
         except Exception as e:
-            log_to_logs_channel(
+            await log_to_logs_channel(
                 title="Image Processing Failed",
                 description=f"{message.author.mention} submitted an image, but it couldn't be resized.\nError: `{str(e)}`",
                 color=discord.Color.red()
             )
             return
 
-        log_to_logs_channel(
+        await log_to_logs_channel(
             title="New Contest Submission",
             description=f"{message.author.mention} submitted an image for the contest.",
             color=discord.Color.green(),


### PR DESCRIPTION
I was getting a "coroutine was never awaited" warning for the calls in `base.py` to send messages to the log channel (and the logs were not being sent, for example, when a submission was recorded).

To fix the warning (and call failure), `await` was added to the `logs_channel.send()` call in `log_to_logs_channel()` (and `log_to_logs_channel()` was transitioned to `async` with all calls to it in `base.py` transitioned to `awaits`).

The offending call: https://github.com/MorrowShore/ContestBot/pull/3/changes/80dca7a83ac4e1826c83e0f3ee89bf0c105ef919#diff-3540be37dd35eeec26b271bd9cbf93db0d2d13f001070f11190109fdcdbef47aR38

I confirmed that no other calls to Discord's `send` method cause issues by running through all the contest job steps without any warnings.